### PR TITLE
Fix CI for #3607 in paritytech/polkadot_sdk

### DIFF
--- a/polkadot/node/service/Cargo.toml
+++ b/polkadot/node/service/Cargo.toml
@@ -142,9 +142,9 @@ polkadot-node-core-pvf-checker = { path = "../core/pvf-checker", optional = true
 polkadot-node-core-runtime-api = { path = "../core/runtime-api", optional = true }
 polkadot-statement-distribution = { path = "../network/statement-distribution", optional = true }
 
-xcm = { package = "staging-xcm", path = "../../xcm", default-features = false }
-xcm-builder = { package = "staging-xcm-builder", path = "../../xcm/xcm-builder", default-features = false }
-xcm-fee-payment-runtime-api = { path = "../../xcm/xcm-fee-payment-runtime-api" }
+xcm = { package = "staging-xcm", path = "../../xcm" }
+xcm-builder = { package = "staging-xcm-builder", path = "../../xcm/xcm-builder" }
+xcm-fee-payment-runtime-api = { package = "xcm-fee-payment-runtime-api", path = "../../xcm/xcm-fee-payment-runtime-api" }
 
 [dev-dependencies]
 polkadot-test-client = { path = "../test/client" }
@@ -210,7 +210,6 @@ runtime-benchmarks = [
 	"service/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"westend-runtime?/runtime-benchmarks",
-	"xcm-builder/runtime-benchmarks",
 ]
 try-runtime = [
 	"frame-support/try-runtime",


### PR DESCRIPTION
- Use default features from xcm and xcm-builder. To make sure we use `std`.
- Don't enable missing feature on xcm-builder. Was suggested by zepter feature propagation but it was wrong.